### PR TITLE
Coroutine under the hood

### DIFF
--- a/CoroutineDeepDive/Part1/코루틴 내부 동작.md
+++ b/CoroutineDeepDive/Part1/코루틴 내부 동작.md
@@ -320,7 +320,8 @@ class PrintUserContinuation(
         
         val res = try {
             val r = printUser(token, this)
-            if (r == COROUTINE_SUSPENDED) return Result.success(r as Unit)
+            if (r == COROUTINE_SUSPENDED) return
+            Result.success(r as Unit)
         } catch (e: Throwable) {
             Result.failure(e)
         }

--- a/CoroutineDeepDive/Part1/코루틴 내부 동작.md
+++ b/CoroutineDeepDive/Part1/코루틴 내부 동작.md
@@ -12,7 +12,7 @@ suspend 함수는 호출이 일시 중단될 수 있고 나중에 다시 재개�
 
 > **상태 기계(State Machines)**  
 > 특정 시스템이 가질 수 있는 "여러 상태"와 그 상태 사이의 전환되는 규칙을 정의하는 수학적 모델,  
-> 상태 기계는 현재 상태와 일련의 전환이나 이벤트에 의해 다른 상태로 이동할 수 있는 규칙을 가지고 있음  
+> 상태 기계는 현재 상태와 일련의 전환이나 이벤트에 의해 다른 상태로 이동할 수 있는 규칙을 가지고 있음
 
 > 코루틴 내의 suspend 함수는 여러 상태를 가질 수 있으며, 일시 중단되는 시점마다 다른 상태로 전환됨  
 > 코루틴 내부에 3개의 일시 중단 지점이 있다면, 4개의 상태를 가질 수 있음(시작 상태, 1번째, 2번째, 3번째 일시 중단 후)
@@ -62,3 +62,105 @@ fun checkAvailability(flight: Flight, continuation: Continuation<*>): Any
 결과 타입은 `User? | Any`의 가장 근접한 상위 타입인 `Any?`이어야 합니다.
 
 만약 언젠가 Kotlin이 union 타입을 도입하게 되면 `User? | COROUTINE_SUSPENDED` 형태로 변경될 것 입니다.
+
+---
+
+## 아주 간단한 함수
+
+코루틴 내부에 더 깊게 들어가기 위해, 지연(Delay) 후 무언가를 출력하는 함수부터 시작 해보겠습니다.
+
+```kotlin
+suspend fun myFunction() {
+    println("Before")
+    delay(1000) // suspending
+    println("After")
+}
+```
+
+위 함수는 내부에서 다음과 같이 변경됩니다.
+
+```kotlin
+fun myFunction(continuation: Continuation<*>): Any
+```
+
+그 다음 이 함수는 상태를 저장하기 위해 자체 `continuation`을 필요로 합니다,.
+
+여기서는 `MyFunctionContinuation`라는 클래스가 생성되고,   
+본문 시작 부분에서 `myFunction`의 `continuation` 파라미터를 위 `MyFunctionContinuation`으로 감쌉니다.
+
+```kotlin
+val continuation = MyFunctionContinuation(continuation)
+```
+
+이는 `continuation`이 감싸져 있지 않은 경우에만 처리하며, 이미 감싸져 있다면 이는 재개 과정의 일부이며, `continuation`을 변경하지 않아야 합니다.
+
+```kotlin
+val continuation =
+    if (continuation is MyFunctionContinuation) continuation 
+    else MyFunctionContinuation(continuation)
+
+// 간단하게 변경
+val continuation = continuation as? MyFunctionContinuation ?: MyFunctionContinuation(continuation)
+```
+
+마지막으로 함수 본문을 보게되면 다음과 같습니다.
+
+```kotlin
+suspend fun myFunction() { 
+    println("Before") 
+    delay(1000) // suspending
+    println("After")
+}
+```
+
+이 함수는 처음부터 시작하거나 일시 중단 후에 시작할 수 있습니다.
+
+현재 상태를 식별하기 위해 `label` 필드를 사용하며, 시작 시 `0`이므로 함수는 처음부터 시작합니다.  
+그러나 일시 중단 지점 직후부터 시작하도록 각 일시 중단 지점 이전에 다음 상태로 `label`을 설정되게 됩니다.
+
+```kotlin
+fun myFunction(continuation: Continuation<*>): Any {
+    val continuation = continuation as? MyFunctionContinuation ?: MyFunctionContinuation(continuation)
+    
+    if (continuation.label == 0) {
+        println("Before")
+        continuation.label = 1
+        if (delay(1000, continuation) == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
+    }
+    
+    if (continuation.label == 1) {
+        println("After")
+        return Unit
+    }
+    error("Impossible")
+}
+```
+
+마지막으로 위 코드를 살펴보면 `delay`로 코루틴이 일시 중단되면 `COROUTINE_SUSPENDED`를 반환하고, `myFunction`도 `COROUTINE_SUSPENDED`를 반환하게 됩니다.
+
+이것이 호출 스택의 최상단까지 전파되어 코루틴 빌더(`launch`, `async` 등) 또는 `resumse` 함수에 도달할 때까지 이어집니다.  
+이러한 동작들이 스레드가 다른 작업(코루틴 포함)에 사용 가능하도록 하는 것입니다.
+
+만약 `delay` 호출이 `COROUTINE_SUSPENDED`를 반환하지 않고 `Unit`을 반환하면 다음 상태로 이동하게 되고, 
+이 함수는 우리가 원하는 것과 다르게 동작하게 될 수 있습니다.
+
+`continuation`에 대해서 계속 살펴보면, `continuation`은 익명 클래스로 아래와 같이 구현됩니다.
+
+```kotlin
+cont = object : ContinuationImpl(continuation) {
+    var result: Any? = null
+    var label = 0
+    
+    override fun invokeSuspend(`$result`: Any?) {
+        this.result = `$result`;
+        return myFunction(this);
+    }
+};
+```
+
+함수의 가독성을 높이기 위해 `ContinuationImpl`이라는 클래스 명으로 표현하였으며, `ContinuationImpl`의 본문을 인라인화하고 별도의 클래스로 나타내고 있습니다.
+이렇게 함으로써 필요한 핵심 부분만 강조하면서 코드를 단순화 할 수 있습니다.
+
+JVM에서는 컴파일 중에 타입 인수가 지워집니다. 따라서 `Continuation<Unit>` 또는 `Continuation<String>`과 같은 구체적인 타입은 모두 `Continuation`으로 처리됩니다.
+
+이것은 Kotlin과 JVM 바이트 코드 간의 표현에 있어 중요한 부분으로 복잡한 제네릭 타입을 다룰 때의 세부 사항을 간소화하는 역할을 합니다.

--- a/CoroutineDeepDive/Part1/코루틴 내부 동작.md
+++ b/CoroutineDeepDive/Part1/코루틴 내부 동작.md
@@ -234,3 +234,98 @@ class MyFunctionContinuation(
     }
 }
 ```
+
+---
+
+## 값으로 재개된 함수
+
+아래 예시는 일시 중단 후 값으로 함수가 재개되는 경우를 다루며, 함수는 2개의 일시 중단 함수와 반환 값을 가지고 있습니다.
+이 또한 모든것은 `Continuation`에서 관리됩니다.
+
+```kotlin
+suspend fun printUser(token: String) {
+    println("Before")
+    val userId = getUserId(token) // suspending
+    println("Got userId: $userId")
+    val userName = getUserName(userId, token) // suspending
+    println(User(userId, userName))
+    println("After")
+}
+```
+
+위 코드를 보면 `getUserId`와 `getUserName`이라는 두 개의 일시 중단 함수가 있습니다.
+또한 `token`이라는 파라미터도 존재하며, 일시 중단 함수는 일부 값을 반환합니다.
+
+이러한 모든 것들은 `continuation`에 저장되어 있어야하며 다음과 같이 사용됩니다.
+
+- `token` : 0과 1 상태에서 필요하므로 `continuation`에 저장되어야 합니다.
+- `userId` : 1과 2 상태에서 필요하므로 `continuation`에 저장되어야 합니다.
+- `result` : `Result` 타입으로 함수가 재개되었을 때 어떻게 재개되었는지를 나타냅니다.
+
+함수가 값으로 재개되었다면, `Result.Success(value)`가 됩니다. 이 경우에는 이 값을 얻고 사용할 수 있습니다.  
+함수가 예외로 재개되었다면, `Result.Failure(exception)`이 됩니다. 이 경우에는 예외가 발생합니다.
+
+```kotlin
+fun printUser(
+    token: String,
+    continuation: Continuation<*>
+): Any {
+    val continuation = continuation as? PrintUserContinuation 
+        ?: PrintUserContinuation(continuation as Continuation<Unit>, token)
+    
+    var result: Result<Any>? = continuation.result
+    var userId: String? = continuation.userId
+    val userName: String
+    
+    if (continuation.label == 0) {
+        println("Before")
+        continuation.label = 1
+        val res = getUserId(token, continuation)
+        if (res == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
+        result = Result.success(res)
+    }
+    
+    if (continuation.label == 1) {
+        userId = result!!.getOrThrow() as String
+        println("Got userId: $userId")
+        continuation.label = 2
+        val res = getUserName(userId, continuation)
+        if (res == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
+        result = Result.success(res)
+    }
+    
+    if (continuation.label == 2) {
+        userName = result!!.getOrThrow() as String
+        println(User(userId!!, userName))
+        println("After")
+        return Unit
+    }
+    
+    error("Impossible")
+}
+
+class PrintUserContinuation(
+    val completion: Continuation<Unit>,
+    val token: String
+) : Continuation<Unit> {
+    override val context: CoroutineContext
+        get() = completion.context
+    
+    var result: Result<Any>? = null
+    var label = 0
+    var userId: String? = null
+    
+    override fun resumeWith(result: Result<Any>) {
+        this.result = result
+        
+        val res = try {
+            val r = printUser(token, this)
+            if (r == COROUTINE_SUSPENDED) return Result.success(r as Unit)
+        } catch (e: Throwable) {
+            Result.failure(e)
+        }
+        
+        completion.resumeWith(res)
+    }
+}
+```

--- a/CoroutineDeepDive/Part1/코루틴 내부 동작.md
+++ b/CoroutineDeepDive/Part1/코루틴 내부 동작.md
@@ -96,7 +96,7 @@ val continuation = MyFunctionContinuation(continuation)
 
 ```kotlin
 val continuation =
-    if (continuation is MyFunctionContinuation) continuation 
+    if (continuation is MyFunctionContinuation) continuation
     else MyFunctionContinuation(continuation)
 
 // 간단하게 변경
@@ -106,8 +106,8 @@ val continuation = continuation as? MyFunctionContinuation ?: MyFunctionContinua
 마지막으로 함수 본문을 보게되면 다음과 같습니다.
 
 ```kotlin
-suspend fun myFunction() { 
-    println("Before") 
+suspend fun myFunction() {
+    println("Before")
     delay(1000) // suspending
     println("After")
 }
@@ -121,13 +121,13 @@ suspend fun myFunction() {
 ```kotlin
 fun myFunction(continuation: Continuation<*>): Any {
     val continuation = continuation as? MyFunctionContinuation ?: MyFunctionContinuation(continuation)
-    
+
     if (continuation.label == 0) {
         println("Before")
         continuation.label = 1
         if (delay(1000, continuation) == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
     }
-    
+
     if (continuation.label == 1) {
         println("After")
         return Unit
@@ -141,7 +141,7 @@ fun myFunction(continuation: Continuation<*>): Any {
 이것이 호출 스택의 최상단까지 전파되어 코루틴 빌더(`launch`, `async` 등) 또는 `resumse` 함수에 도달할 때까지 이어집니다.  
 이러한 동작들이 스레드가 다른 작업(코루틴 포함)에 사용 가능하도록 하는 것입니다.
 
-만약 `delay` 호출이 `COROUTINE_SUSPENDED`를 반환하지 않고 `Unit`을 반환하면 다음 상태로 이동하게 되고, 
+만약 `delay` 호출이 `COROUTINE_SUSPENDED`를 반환하지 않고 `Unit`을 반환하면 다음 상태로 이동하게 되고,
 이 함수는 우리가 원하는 것과 다르게 동작하게 될 수 있습니다.
 
 `continuation`에 대해서 계속 살펴보면, `continuation`은 익명 클래스로 아래와 같이 구현됩니다.
@@ -150,7 +150,7 @@ fun myFunction(continuation: Continuation<*>): Any {
 cont = object : ContinuationImpl(continuation) {
     var result: Any? = null
     var label = 0
-    
+
     override fun invokeSuspend(`$result`: Any?) {
         this.result = `$result`;
         return myFunction(this);
@@ -191,16 +191,16 @@ suspend fun myFunction() {
 ```kotlin
 fun myFunction(continuation: Continuation<*>): Any {
     val continuation = continuation as? MyFunctionContinuation ?: MyFunctionContinuation(continuation)
-    
+
     var counter = continuation.counter
-    
+
     if (continuation.label == 0) {
         println("Before")
         continuation.counter = 0
         continuation.label = 1
         if (delay(1000, continuation) == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
     }
-    
+
     if (continuation.label == 1) {
         counter = (counter as Int) + 1
         println("Counter: $counter")
@@ -215,21 +215,21 @@ class MyFunctionContinuation(
 ) : Continuation<Unit> {
     override val context: CoroutineContext
         get() = completion.context
-    
+
     var result: Result<Unit>? = null
     var label = 0
     var counter = 0
-    
+
     override fun resumeWith(result: Result<Unit>) {
         this.result = result
-        
+
         val res = try {
             val r = myFunction(this)
             if (r == COROUTINE_SUSPENDED) return Result.success(r as Unit)
         } catch (e: Throwable) {
             Result.failure(e)
         }
-        
+
         completion.resumeWith(res)
     }
 }
@@ -270,13 +270,13 @@ fun printUser(
     token: String,
     continuation: Continuation<*>
 ): Any {
-    val continuation = continuation as? PrintUserContinuation 
+    val continuation = continuation as? PrintUserContinuation
         ?: PrintUserContinuation(continuation as Continuation<Unit>, token)
-    
+
     var result: Result<Any>? = continuation.result
     var userId: String? = continuation.userId
     val userName: String
-    
+
     if (continuation.label == 0) {
         println("Before")
         continuation.label = 1
@@ -284,7 +284,7 @@ fun printUser(
         if (res == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
         result = Result.success(res)
     }
-    
+
     if (continuation.label == 1) {
         userId = result!!.getOrThrow() as String
         println("Got userId: $userId")
@@ -293,14 +293,14 @@ fun printUser(
         if (res == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
         result = Result.success(res)
     }
-    
+
     if (continuation.label == 2) {
         userName = result!!.getOrThrow() as String
         println(User(userId!!, userName))
         println("After")
         return Unit
     }
-    
+
     error("Impossible")
 }
 
@@ -310,14 +310,14 @@ class PrintUserContinuation(
 ) : Continuation<Unit> {
     override val context: CoroutineContext
         get() = completion.context
-    
+
     var result: Result<Any>? = null
     var label = 0
     var userId: String? = null
-    
+
     override fun resumeWith(result: Result<Any>) {
         this.result = result
-        
+
         val res = try {
             val r = printUser(token, this)
             if (r == COROUTINE_SUSPENDED) return
@@ -325,8 +325,96 @@ class PrintUserContinuation(
         } catch (e: Throwable) {
             Result.failure(e)
         }
-        
+
         completion.resumeWith(res)
     }
 }
 ```
+
+---
+
+## 호출 스택
+
+함수 a가 함수 b를 호출할 때, 가상 머신은 a의 상태를 저장해야 하며, b가 완료되면 실행이 어디로 돌아가야 하는지에 대한 주소도 저장해야 합니다.
+이 모든 것은 호출 스택이라는 구조체에 저장됩니다. (호출 스택에는 제한된 공간이 있으며 모두 사용되면 StackOverflow가 발생됩니다.)
+
+여기서 문제는 코루틴이 일시 중단될 때 스레드를 해제하므로, 호출 스택을 지워버립니다. 따라서 호출 스택은 재개될 때 유용하지 않습니다.
+대신, `continuation`이 호출 스택 역할을 하게됩니다. 
+각 `continuation`은 일시 중단된 상태(`label`), 함수의 로컬 변수 및 파라미터(필드), 이 함수를 호출한 함수의 `continuation`에 대한 참조를 유지합니다.
+하나의 `continuation`은 다른 `continuation`을 참조하고, 다른 `continuation`을 참조하고, 이런식으로 계속됩니다.
+
+결과적으로, `continuation`은 거대한 양파처럼 보이며 이러한 호출 스택에는 일반적으로 저장되는 모든 것을 유지합니다.
+
+```kotlin
+suspend fun a() {
+    val user = readUser()
+    b()
+    b()
+    b()
+    println(user)
+}
+
+suspend fun b() {
+    for (i in 1..10) {
+        c(i)
+    }
+}
+
+suspend fun c(i: Int) {
+    delay(i * 100L)
+    println("Tick")
+}
+```
+
+위 예제 코드의 `continuation`은 다음과 같이 표현될 수 있습니다.
+
+```text
+CContinuation(
+    i = 4,
+    label = 1,
+    completion = BContinuation(
+        i = 4,
+        label = 1,
+        completion = AContinuation(
+            label = 2,
+            user = User@1234,
+            completion = ...
+        )
+    )
+)
+```
+
+위 표현을 보면, "Tick"이 몇 번 출력되었는지 알 수 있습니다. (단, 여기서 `readUser`는 일시 중단 함수가 아닙니다.)
+
+`AContinuation`의 `label`이 2이므로, 하나의 `b`함수 호출이 이미 완료되었습니다. (이는 10번의 "Tick"을 의미합니다.)
+파라미터 `i`가 4이므로 `b`함수에서 이미 3개의 "Tick"이 출력되었습니다. 즉 "Tick"은 13번 출력되었습니다.
+
+`continuation`이 재개되면, 각 `continuation`은 먼저 함수를 호출합니다. 
+이것이 완료되면, 이 `continuation`은 함수를 호출한 함수의 `continuation`을 재개합니다.
+이 `continuation`은 함수를 호출하고, 이 과정을 스택의 맨 위에 도달할 때까지 반복됩니다.
+
+```kotlin
+override fun resumeWith(result: Result<String>) {
+    this.result = result
+    val res = try {
+        val r = printUser(token, this)
+        if (r == COROUTINE_SUSPENDED) return
+        Result.success(r as Unit)
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }
+
+    completion.resumeWith(res)
+}
+
+```
+
+예를 들어 `a()`가 `b()`를 호출하고, `b()`가 `c()`를 호출하고, `c()`가 일시 중단되었다고 가정해봅시다.
+
+재개될 때, `c`의 `continuation`은 먼저 `c` 함수를 재개하며 이 함수가 완료되면, `c`의 `continuation`은 `b`의 `continuation`을 재개합니다.
+완료되면, `b`의 `continuation`은 `a`의 `continuation`을 재개합니다.
+
+예외 처리는 `continuation`과 유사하게 동작되며 처리되지 않은 예외의 경우 `resumeWith`에서 잡히게되며 `Result.failure(e)` 결과로 함수를 호출한 함수가 재개 됩니다.
+
+상태는 `continuation`에 저장되어야 하며, 일시 중단 메커니즘이 지원되어야 합니다.    
+재개될 때는 `continuation`에서 상태를 복원하고 결과를 사용하거나 예외를 발생시켜야 합니다.

--- a/CoroutineDeepDive/Part1/코루틴 내부 동작.md
+++ b/CoroutineDeepDive/Part1/코루틴 내부 동작.md
@@ -164,3 +164,73 @@ cont = object : ContinuationImpl(continuation) {
 JVM에서는 컴파일 중에 타입 인수가 지워집니다. 따라서 `Continuation<Unit>` 또는 `Continuation<String>`과 같은 구체적인 타입은 모두 `Continuation`으로 처리됩니다.
 
 이것은 Kotlin과 JVM 바이트 코드 간의 표현에 있어 중요한 부분으로 복잡한 제네릭 타입을 다룰 때의 세부 사항을 간소화하는 역할을 합니다.
+
+---
+
+## 상태가 있는 함수
+
+함수에 일시 중단 후 복원되어야 할 로컬 변수나 파라미터와 같은 상태가 있다면, 이 상태는 이 함수의 `continuation`에 저장되어야 합니다.
+
+```kotlin
+suspend fun myFunction() {
+    println("Before")
+    var counter = 0
+    delay(1000) // suspending
+    counter++
+    println("Counter: $counter")
+    println("After")
+}
+```
+
+여기서 `counter`는 두 상태(label이 0과 1일 때)에서 필요하므로 `continuation`에서 저장되어야 합니다.
+
+이것은 일시 정지 직전에 저장되며 이러한 종류의 속성을 복원하는 것은 함수의 시작 부분에서 일어나게 됩니다.
+
+아래 코드는 내부에서 단순화된 함수입니다.
+
+```kotlin
+fun myFunction(continuation: Continuation<*>): Any {
+    val continuation = continuation as? MyFunctionContinuation ?: MyFunctionContinuation(continuation)
+    
+    var counter = continuation.counter
+    
+    if (continuation.label == 0) {
+        println("Before")
+        continuation.counter = 0
+        continuation.label = 1
+        if (delay(1000, continuation) == COROUTINE_SUSPENDED) return COROUTINE_SUSPENDED
+    }
+    
+    if (continuation.label == 1) {
+        counter = (counter as Int) + 1
+        println("Counter: $counter")
+        println("After")
+        return Unit
+    }
+    error("Impossible")
+}
+
+class MyFunctionContinuation(
+    val completion: Continuation<Unit>
+) : Continuation<Unit> {
+    override val context: CoroutineContext
+        get() = completion.context
+    
+    var result: Result<Unit>? = null
+    var label = 0
+    var counter = 0
+    
+    override fun resumeWith(result: Result<Unit>) {
+        this.result = result
+        
+        val res = try {
+            val r = myFunction(this)
+            if (r == COROUTINE_SUSPENDED) return Result.success(r as Unit)
+        } catch (e: Throwable) {
+            Result.failure(e)
+        }
+        
+        completion.resumeWith(res)
+    }
+}
+```


### PR DESCRIPTION
- `continuation.label`을 통한 일수 중단 지점 판별 및 `COROUTINE_SUSPEND`을 통한 호출 스택 전파
- `continuation` 로컬 변수, 파라미터, 값을 통한 재개 등의 상태들 저장
- 함수 호출 스택은 코루틴의 경우 스레드에서 해제될 때 사라지므로 `continuation`이 이 호출 스택의 역할을 함